### PR TITLE
Update plspm for the latest pandas version 

### DIFF
--- a/plspm/bootstrap.py
+++ b/plspm/bootstrap.py
@@ -55,13 +55,13 @@ class BootstrapProcess(Process):
             try:
                 boot_observations = np.random.randint(observations, size=observations)
                 _final_data, _scores, _weights = estimator.estimate(self.__calculator, self.__data.iloc[boot_observations, :])
-                weights = weights.append(_weights.T, ignore_index=True)
+                weights = pd.concat([weights, _weights.T], ignore_index = True)
                 inner_model = im.InnerModel(self.__config.path(), _scores)
-                r_squared = r_squared.append(inner_model.r_squared().T, ignore_index=True)
-                total_effects = total_effects.append(inner_model.effects().loc[:, "total"].T, ignore_index=True)
-                paths = paths.append(inner_model.effects().loc[:, "direct"].T, ignore_index=True)
-                loadings = loadings.append(
-                    (_scores.apply(lambda s: _final_data.corrwith(s)) * self.__config.odm(self.__config.path())).sum(axis=1), ignore_index=True)
+                r_squared = pd.concat([r_squared, inner_model.r_squared().to_frame().T], ignore_index=True)
+                total_effects = pd.concat([total_effects, inner_model.effects().loc[:, "total"].to_frame().T], ignore_index=True)
+                paths = pd.concat([paths, inner_model.effects().loc[:, "direct"].to_frame().T], ignore_index=True)
+                loadings = pd.concat([loadings,
+                                      (_scores.apply(lambda s: _final_data.corrwith(s)) * self.__config.odm(self.__config.path())).sum(axis=1).to_frame().T], ignore_index=True)
             except:
                 pass
         results = {}
@@ -98,11 +98,11 @@ class Bootstrap:
             try:
                 while True:
                     results = queue.get(False)
-                    weights = weights.append(results["weights"])
-                    r_squared = r_squared.append(results["r_squared"])
-                    total_effects = total_effects.append(results["total_effects"])
-                    paths = paths.append(results["paths"])
-                    loadings = loadings.append(results["loadings"])
+                    weights = pd.concat([weights, results["weights"]])
+                    r_squared = pd.concat([r_squared, results["r_squared"]])
+                    total_effects = pd.concat([total_effects, results["total_effects"]])
+                    paths = pd.concat([paths, results["paths"]])
+                    loadings = pd.concat([loadings, results["loadings"]])
             except Empty:
                 pass
             time.sleep(1)

--- a/plspm/bootstrap.py
+++ b/plspm/bootstrap.py
@@ -22,7 +22,7 @@ from plspm.weights import WeightsCalculatorFactory
 from plspm.estimator import Estimator
 
 def _create_summary(data: pd.DataFrame, original):
-    summary = pd.DataFrame(0, index=data.columns, columns=["original", "mean", "std.error", "perc.025", "perc.975", "t stat."])
+    summary = pd.DataFrame(0.0, index=data.columns, columns=["original", "mean", "std.error", "perc.025", "perc.975", "t stat."])
     summary.loc[:, "mean"] = data.mean(axis=0)
     summary.loc[:, "std.error"] = data.std(axis=0)
     summary.loc[:, "perc.025"] = data.quantile(0.025, axis=0)
@@ -43,11 +43,11 @@ class BootstrapProcess(Process):
         self.__iterations = iterations
 
     def run(self):
-        weights = pd.DataFrame(columns=self.__data.columns)
-        r_squared = pd.DataFrame(columns=self.__inner_model.r_squared().index)
-        total_effects = pd.DataFrame(columns=self.__inner_model.effects().index)
-        paths = pd.DataFrame(columns=self.__inner_model.effects().index)
-        loadings = pd.DataFrame(columns=self.__data.columns)
+        weights = pd.DataFrame(columns=self.__data.columns, dtype="float")
+        r_squared = pd.DataFrame(columns=self.__inner_model.r_squared().index, dtype="float")
+        total_effects = pd.DataFrame(columns=self.__inner_model.effects().index, dtype="float")
+        paths = pd.DataFrame(columns=self.__inner_model.effects().index, dtype="float")
+        loadings = pd.DataFrame(columns=self.__data.columns, dtype="float")
 
         observations = self.__data.shape[0]
         estimator = Estimator(self.__config)
@@ -58,8 +58,10 @@ class BootstrapProcess(Process):
                 weights = pd.concat([weights, _weights.T], ignore_index = True)
                 inner_model = im.InnerModel(self.__config.path(), _scores)
                 r_squared = pd.concat([r_squared, inner_model.r_squared().to_frame().T], ignore_index=True)
-                total_effects = pd.concat([total_effects, inner_model.effects().loc[:, "total"].to_frame().T], ignore_index=True)
-                paths = pd.concat([paths, inner_model.effects().loc[:, "direct"].to_frame().T], ignore_index=True)
+                total_effects = pd.concat([total_effects,
+                                           inner_model.effects().loc[:, "total"].to_frame().T], ignore_index=True)
+                paths = pd.concat([paths,
+                                   inner_model.effects().loc[:, "direct"].to_frame().T], ignore_index=True)
                 loadings = pd.concat([loadings,
                                       (_scores.apply(lambda s: _final_data.corrwith(s)) * self.__config.odm(self.__config.path())).sum(axis=1).to_frame().T], ignore_index=True)
             except:
@@ -80,11 +82,11 @@ class Bootstrap:
     """
     def __init__(self, config: c.Config, data: pd.DataFrame, inner_model: im.InnerModel, outer_model: om.OuterModel,
                  calculator: WeightsCalculatorFactory, iterations: int, num_processes: int):
-        weights = pd.DataFrame(columns=data.columns)
-        r_squared = pd.DataFrame(columns=inner_model.r_squared().index)
-        total_effects = pd.DataFrame(columns=inner_model.effects().index)
-        paths = pd.DataFrame(columns=inner_model.effects().index)
-        loadings = pd.DataFrame(columns=data.columns)
+        weights = pd.DataFrame(columns=data.columns, dtype="float")
+        r_squared = pd.DataFrame(columns=inner_model.r_squared().index, dtype="float")
+        total_effects = pd.DataFrame(columns=inner_model.effects().index, dtype="float")
+        paths = pd.DataFrame(columns=inner_model.effects().index, dtype="float")
+        loadings = pd.DataFrame(columns=data.columns, dtype="float")
 
         queue = Queue()
         processes = []

--- a/plspm/inner_model.py
+++ b/plspm/inner_model.py
@@ -46,10 +46,14 @@ def _effects(path: pd.DataFrame):
     for from_lv in list(path):
         for to_lv in list(path):
             if from_lv != to_lv and total_paths.loc[to_lv, from_lv] != 0:
-                effect = pd.Series({"from": from_lv, "to": to_lv, "direct": path.loc[to_lv, from_lv],
-                                    "indirect": indirect_paths.loc[to_lv, from_lv],
-                                    "total": total_paths.loc[to_lv, from_lv]}, name=from_lv + " -> " + to_lv)
-                effects = effects.append(effect)
+                effect = pd.DataFrame([{
+                        "from": from_lv,
+                        "to": to_lv,
+                        "direct": path.loc[to_lv, from_lv],
+                        "indirect": indirect_paths.loc[to_lv, from_lv],
+                        "total": total_paths.loc[to_lv, from_lv]
+                    }], index=[from_lv + " -> " + to_lv])
+                effects = pd.concat([effects, effect])
     return effects
 
 
@@ -71,7 +75,7 @@ class InnerModel:
             rsquared = regression.rsquared
             self.__r_squared.loc[dv] = rsquared
             self.__r_squared_adj.loc[dv] = 1 - (1 - rsquared) * (rows - 1) / (rows - path.loc[dv].sum() - 1)
-            self.__summaries = self.__summaries.append(_summary(dv, regression)).reset_index(drop=True)
+            self.__summaries = pd.concat([self.__summaries, _summary(dv, regression)]).reset_index(drop=True)
         self.__effects = _effects(self.__path_coefficients)
 
     def path_coefficients(self) -> pd.DataFrame:

--- a/plspm/inner_model.py
+++ b/plspm/inner_model.py
@@ -32,7 +32,11 @@ def _summary(dv, regression):
 
 def _effects(path: pd.DataFrame):
     indirect_paths = pd.DataFrame(0, index=path.index, columns=path.columns)
-    effects = pd.DataFrame(columns=["from", "to", "direct", "indirect", "total"])
+    effects = pd.DataFrame({"from":     pd.Series(dtype="str"),
+                            "to":       pd.Series(dtype="str"),
+                            "direct":   pd.Series(dtype="float"),
+                            "indirect": pd.Series(dtype="float"),
+                            "total":    pd.Series(dtype="float")})
     num_lvs = len(list(path))
     if (num_lvs == 2):
         total_paths = path
@@ -60,10 +64,10 @@ def _effects(path: pd.DataFrame):
 class InnerModel:
     """Internal class that calculates the attributes of the inner model. Use the methods :meth:`~plspm.Plspm.inner_model`, :meth:`~plspm.Plspm.path_coefficients`, and :meth:`~plspm.Plspm.effects` defined on :class:`~.plspm.Plspm` to retrieve the inner model characteristics."""
     def __init__(self, path: pd.DataFrame, scores: pd.DataFrame):
-        self.__summaries = pd.DataFrame()
-        self.__r_squared = pd.Series(0, index=path.index, name="r_squared")
-        self.__r_squared_adj = pd.Series(0, index=path.index, name="r_squared_adj")
-        self.__path_coefficients = pd.DataFrame(0, columns=path.columns, index=path.index)
+        self.__summaries = None
+        self.__r_squared = pd.Series(0.0, index=path.index, name="r_squared")
+        self.__r_squared_adj = pd.Series(0.0, index=path.index, name="r_squared_adj")
+        self.__path_coefficients = pd.DataFrame(0.0, columns=path.columns, index=path.index)
         endogenous = path.sum(axis=1).astype(bool)
         self.__endogenous = list(endogenous[endogenous == True].index)
         rows = scores.shape[0]

--- a/plspm/unidimensionality.py
+++ b/plspm/unidimensionality.py
@@ -29,8 +29,13 @@ class Unidimensionality:
 
     def summary(self):
         """Internal method that performs principal component analysis to compute various reliability metrics."""
-        summary = pd.DataFrame(np.NaN, index=list(self.__config.path()),
-                               columns=["mode", "mvs", "cronbach_alpha", "dillon_goldstein_rho", "eig_1st", "eig_2nd"])
+        summary = pd.DataFrame({"mode":                 pd.Series(dtype="str"),
+                                "mvs":                  pd.Series(dtype="float"),
+                                "cronbach_alpha":       pd.Series(dtype="float"),
+                                "dillon_goldstein_rho": pd.Series(dtype="float"),
+                                "eig_1st":              pd.Series(dtype="float"),
+                                "eig_2nd":              pd.Series(dtype="float")},
+                                 index=list(self.__config.path()))
         for lv in list(self.__config.path()):
             mvs = len(self.__config.mvs(lv))
             summary.loc[lv, "mode"] = self.__config.mode(lv).name

--- a/plspm/weights.py
+++ b/plspm/weights.py
@@ -61,7 +61,7 @@ class _MetricWeights:
         cor = pd.concat([self.__data, scores], axis=1).corr().loc[list(self.__data), list(scores)]
         odm = weights.apply(lambda x: x!= 0).astype(int)
         sign = lambda x : math.copysign(1.0, x)
-        w_sign = (cor * odm).applymap(sign).sum(axis=0).apply(sign)
+        w_sign = (cor * odm).map(sign).sum(axis=0).apply(sign)
         if -1 in w_sign.values:
             w_sign = w_sign.apply(lambda x : -1 if x == 0 else x)
             w_sign_matrix = pd.DataFrame(np.diag(w_sign), index=w_sign.index, columns=w_sign.index)
@@ -121,11 +121,11 @@ class _NonmetricWeights:
 
     def calculate(self) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
         lvs = list(self.__path)
-        weights = pd.DataFrame(0, index=self.__mvs, columns=lvs)
-        data_new = pd.DataFrame(0, index=self.__index, columns=self.__mvs)
+        weights = pd.DataFrame(0.0, index=self.__mvs, columns=lvs)
+        data_new = pd.DataFrame(0.0, index=self.__index, columns=self.__mvs)
         for lv in lvs:
             mvs = self.__config.mvs(lv)
-            weights.loc[mvs, [lv]] = self.__weights[lv]
+            weights.loc[mvs, [lv]] = self.__weights[lv].reshape(self.__weights[lv].shape[0],1)
             data_new.loc[:, mvs] = self.__mv_grouped_by_lv[lv]
         weight_factors = 1 / (data_new.dot(weights).std(axis=0, skipna=True) / self.__correction)
         wf_diag = pd.DataFrame(np.diag(weight_factors), index=lvs, columns=lvs)

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="plspm",
-    version="0.5.6",
+    version="0.5.7",
     author="Jez Humble",
     author_email="humble@google.com",
     description="A library implementing the Partial Least Squares Path Model algorithm",


### PR DESCRIPTION
Hi,

Thanks for the great python module! I've used plspm lately and ran into the same issues reported in #11.  This pull request updates plspm to address these issues with newer versions of pandas. 

- I have replaced all calls to .append with .concat, as this was recommended in the previous deprecation warning.
- Additionally, newer versions of pandas did raise warnings about concatenating empty data frames with non-empty ones if the dtypes did not match. I have therefore also replaced those empty data frames with data frames where the dtypes are specified
- I replaced a call applymap with map because applymap is deprecated.
- I have updated the package version

The updated package passed all tests included in the tests folder. However, the bootstrapping test fails randomly; I assume this is due to the random subsetting of the data in the bootstrapping procedure.

Best,
Jannik